### PR TITLE
feat: binary validation report with json, catalog-aware imports

### DIFF
--- a/crates/ps5-cli/src/cli.rs
+++ b/crates/ps5-cli/src/cli.rs
@@ -21,6 +21,8 @@ pub enum Commands {
         file: PathBuf,
         #[arg(long)]
         json: bool,
+        #[arg(long)]
+        catalog: bool,
         #[arg(short, long, value_hint = ValueHint::FilePath)]
         output: Option<PathBuf>,
     },
@@ -68,9 +70,8 @@ pub enum Commands {
         include_modules: bool,
     },
     Validate {
-        path: PathBuf,
-        #[arg(short, long, value_hint = ValueHint::FilePath)]
-        output: Option<PathBuf>,
+        #[command(subcommand)]
+        command: ValidateCommand,
     },
     Dashboard {
         path: PathBuf,
@@ -161,6 +162,24 @@ pub enum CatalogCommand {
         url: Option<String>,
         #[arg(short, long)]
         submitter: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ValidateCommand {
+    /// Validate a PS5 binary's structural metrics
+    Binary {
+        file: PathBuf,
+        #[arg(long)]
+        json: bool,
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
+        output: Option<PathBuf>,
+    },
+    /// Validate a scan dataset directory
+    Dataset {
+        path: PathBuf,
+        #[arg(short, long, value_hint = ValueHint::FilePath)]
+        output: Option<PathBuf>,
     },
 }
 

--- a/crates/ps5-cli/src/inspect.rs
+++ b/crates/ps5-cli/src/inspect.rs
@@ -111,10 +111,19 @@ pub(crate) fn cmd_inspect(path: &PathBuf, json: bool, output: &Option<PathBuf>) 
 }
 
 #[allow(clippy::print_literal)]
-pub(crate) fn cmd_imports(path: &PathBuf, json: bool, output: &Option<PathBuf>) {
+pub(crate) fn cmd_imports(
+    path: &PathBuf,
+    json: bool,
+    catalog_mode: bool,
+    output: &Option<PathBuf>,
+) {
     let data = load_file(path);
     let sha256 = ps5_format::sha256_hex(&data);
-    let catalog = ps5_nid::Catalog::new();
+    let catalog = if catalog_mode {
+        load_catalog(&[])
+    } else {
+        ps5_nid::Catalog::new()
+    };
     let image = ps5_image::BinaryImageBuilder::build_from_file(&data, &sha256, &catalog);
 
     if json {
@@ -125,12 +134,22 @@ pub(crate) fn cmd_imports(path: &PathBuf, json: bool, output: &Option<PathBuf>) 
     }
 
     println!("Imports from {} ({})", path.display(), image.imports.len());
-    println!("{:<64} {:<16} {}", "NID", "Resolved", "Library");
-    println!("{}", "-".repeat(100));
-
-    for imp in &image.imports {
-        let resolved = imp.resolved_name.as_deref().unwrap_or("?");
-        println!("{:<64} {:<16} {}", imp.nid_hash, resolved, imp.library_name);
+    if catalog_mode {
+        println!("{:<64} {:<32} {:<16}", "NID", "Resolved", "Library");
+        println!("{}", "-".repeat(120));
+        for imp in &image.imports {
+            let resolved = imp.resolved_name.as_deref().unwrap_or("?");
+            println!(
+                "{:<64} {:<32} {:<16}",
+                imp.nid_hash, resolved, imp.library_name
+            );
+        }
+    } else {
+        println!("{:<64} {:<16}", "NID", "Library");
+        println!("{}", "-".repeat(84));
+        for imp in &image.imports {
+            println!("{:<64} {:<16}", imp.nid_hash, imp.library_name);
+        }
     }
 }
 

--- a/crates/ps5-cli/src/inspect.rs
+++ b/crates/ps5-cli/src/inspect.rs
@@ -230,7 +230,7 @@ pub(crate) fn cmd_exports(
         println!("  No exports found");
         return;
     }
-    println!("{:<20} {:<50} {:<20} {}", "NID", "Name", "Address", "Size");
+    println!("{:<20} {:<50} {:<20} Size", "NID", "Name", "Address");
     println!("{}", "-".repeat(110));
     for r in &rows {
         println!("{:<20} {:<50} {:<20} {}", r.nid, r.name, r.address, r.size);

--- a/crates/ps5-cli/src/load.rs
+++ b/crates/ps5-cli/src/load.rs
@@ -70,10 +70,10 @@ fn scan_prx_dir(dir: &Path) -> Vec<(String, PathBuf)> {
             std::process::exit(1);
         });
         let path = entry.path();
-        if path.is_file() {
-            if let Some(name) = path.file_name().map(|s| s.to_string_lossy().to_string()) {
-                entries.push((name, path));
-            }
+        if path.is_file()
+            && let Some(name) = path.file_name().map(|s| s.to_string_lossy().to_string())
+        {
+            entries.push((name, path));
         }
     }
     entries
@@ -235,10 +235,10 @@ fn print_modules(ctx: &ps5_loader::ModuleContext) {
         if let Some(entry) = module.entry_point {
             println!("      Entry: {:#018x}", entry);
         }
-        if let Some(ref soname) = module.soname {
-            if soname != &module.name {
-                println!("      SONAME: {soname}");
-            }
+        if let Some(ref soname) = module.soname
+            && soname != &module.name
+        {
+            println!("      SONAME: {soname}");
         }
         if let Some(ref tls) = module.tls {
             println!(
@@ -417,7 +417,7 @@ pub(crate) fn cmd_load(path: &PathBuf, prx_dir: Option<PathBuf>, json: bool) {
 }
 
 /// Multi-module mode: load eboot + PRXs from `--prx-dir`.
-fn cmd_load_multi(path: &PathBuf, data: &[u8], prx_dir: &Path, json: bool) {
+fn cmd_load_multi(path: &Path, data: &[u8], prx_dir: &Path, json: bool) {
     let container = container_name(data);
     let elf_bytes = get_elf_bytes(data);
 
@@ -515,7 +515,7 @@ fn cmd_load_multi(path: &PathBuf, data: &[u8], prx_dir: &Path, json: bool) {
 }
 
 /// Single-file mode (legacy): load one binary with no PRX resolution.
-fn cmd_load_single(path: &PathBuf, data: &[u8], json: bool) {
+fn cmd_load_single(path: &Path, data: &[u8], json: bool) {
     let container = container_name(data);
     let elf_bytes = get_elf_bytes(data);
 

--- a/crates/ps5-cli/src/main.rs
+++ b/crates/ps5-cli/src/main.rs
@@ -12,15 +12,21 @@ mod load;
 mod strings;
 mod terminal;
 mod util;
+mod validate;
 
-use cli::{CatalogCommand, Cli, Commands};
+use cli::{CatalogCommand, Cli, Commands, ValidateCommand};
 
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Inspect { file, json, output } => inspect::cmd_inspect(&file, json, &output),
-        Commands::Imports { file, json, output } => inspect::cmd_imports(&file, json, &output),
+        Commands::Imports {
+            file,
+            json,
+            catalog,
+            output,
+        } => inspect::cmd_imports(&file, json, catalog, &output),
         Commands::Segments { file } => inspect::cmd_segments(&file),
         Commands::Dynamic { file } => inspect::cmd_dynamic(&file),
         Commands::Symbols { file } => inspect::cmd_symbols(&file),
@@ -43,7 +49,12 @@ fn main() {
             nids,
             include_modules,
         } => extract::cmd_batch_extract(&path, &output, &nids, include_modules),
-        Commands::Validate { path, output } => dataset::cmd_validate(&path, &output),
+        Commands::Validate { command } => match command {
+            ValidateCommand::Binary { file, json, output } => {
+                validate::cmd_validate_binary(&file, json, &output)
+            }
+            ValidateCommand::Dataset { path, output } => dataset::cmd_validate(&path, &output),
+        },
         Commands::Dashboard { path, output } => dataset::cmd_dashboard(&path, &output),
         Commands::ExportUnknown {
             path,

--- a/crates/ps5-cli/src/validate.rs
+++ b/crates/ps5-cli/src/validate.rs
@@ -1,0 +1,272 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+use crate::catalog::load_catalog;
+use crate::util::{load_file, write_to_output_or_stdout};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Serialize)]
+struct ValidationReport {
+    schema_version: u32,
+    tool: &'static str,
+    file: String,
+    sha256: String,
+    container: String,
+    platform: String,
+    elf: ElfInfo,
+    dependencies: DependencyInfo,
+    symbols: SymbolCounts,
+    relocations: RelocationInfo,
+    plt: PltInfo,
+    nid_coverage: NidCoverage,
+    unknown_nids: Vec<String>,
+    warnings: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ElfInfo {
+    arch: String,
+    pie: bool,
+    entry_point: String,
+}
+
+#[derive(Serialize)]
+struct DependencyInfo {
+    count: usize,
+    libraries: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct SymbolCounts {
+    imports: usize,
+    exports: usize,
+}
+
+#[derive(Serialize)]
+struct RelocationInfo {
+    total: usize,
+    by_kind: Vec<KindCount>,
+}
+
+#[derive(Serialize)]
+struct KindCount {
+    kind: String,
+    count: usize,
+}
+
+#[derive(Serialize)]
+struct PltInfo {
+    entries: usize,
+}
+
+#[derive(Serialize)]
+struct NidCoverage {
+    known: usize,
+    unknown: usize,
+}
+
+fn reloc_kind_name(kind: ps5_image::RelocationKind) -> String {
+    let name = match kind {
+        ps5_image::RelocationKind::None => "NONE",
+        ps5_image::RelocationKind::_64 => "ABS64",
+        ps5_image::RelocationKind::PC32 => "PC32",
+        ps5_image::RelocationKind::GOT32 => "GOT32",
+        ps5_image::RelocationKind::PLT32 => "PLT32",
+        ps5_image::RelocationKind::Copy => "COPY",
+        ps5_image::RelocationKind::GlobDat => "GLOB_DAT",
+        ps5_image::RelocationKind::JumpSlot => "JUMP_SLOT",
+        ps5_image::RelocationKind::Relative => "RELATIVE",
+        ps5_image::RelocationKind::Direct32 => "DIRECT32",
+        ps5_image::RelocationKind::Direct32S => "DIRECT32S",
+        ps5_image::RelocationKind::Direct16 => "DIRECT16",
+        ps5_image::RelocationKind::PC16 => "PC16",
+        ps5_image::RelocationKind::Direct8 => "DIRECT8",
+        ps5_image::RelocationKind::PC8 => "PC8",
+        ps5_image::RelocationKind::TPOff64 => "TPOFF64",
+        ps5_image::RelocationKind::TPOff32 => "TPOFF32",
+        ps5_image::RelocationKind::DTPMod64 => "DTPMOD64",
+        ps5_image::RelocationKind::DTPOff64 => "DTPOFF64",
+        ps5_image::RelocationKind::TLSDESC => "TLSDESC",
+        ps5_image::RelocationKind::TlsModOff => "TLS_MOD_OFF",
+        ps5_image::RelocationKind::TlsOffset => "TLS_OFFSET",
+        ps5_image::RelocationKind::Other(v) => return format!("OTHER({v})"),
+    };
+    name.to_string()
+}
+
+fn build_report(path: &PathBuf) -> ValidationReport {
+    let data = load_file(path);
+    let sha256 = ps5_format::sha256_hex(&data);
+    let catalog = load_catalog(&[]);
+    let image = ps5_image::BinaryImageBuilder::build_from_file(&data, &sha256, &catalog);
+
+    let mut by_kind = BTreeMap::<String, usize>::new();
+    let mut plt_entries = 0usize;
+    for reloc in &image.relocations {
+        *by_kind.entry(reloc_kind_name(reloc.kind)).or_insert(0) += 1;
+        if reloc.is_plt {
+            plt_entries += 1;
+        }
+    }
+    let by_kind: Vec<KindCount> = by_kind
+        .into_iter()
+        .map(|(kind, count)| KindCount { kind, count })
+        .collect();
+
+    let known = image
+        .imports
+        .iter()
+        .filter(|i| i.resolved_name.is_some())
+        .count();
+    let unknown = image.imports.len() - known;
+
+    let mut unknown_nids: Vec<String> = image
+        .imports
+        .iter()
+        .filter(|i| i.resolved_name.is_none())
+        .map(|i| i.nid_hash.clone())
+        .collect();
+    unknown_nids.sort();
+    unknown_nids.dedup();
+
+    let jump_slot = by_kind
+        .iter()
+        .find(|k| k.kind == "JUMP_SLOT")
+        .map_or(0, |k| k.count);
+
+    let mut warnings = Vec::new();
+    if plt_entries != jump_slot {
+        warnings.push(format!(
+            "plt relocations ({plt_entries}) do not match JUMP_SLOT relocations ({jump_slot})"
+        ));
+    }
+    let mut seen = HashSet::new();
+    for imp in &image.imports {
+        if !seen.insert(imp.nid_hash.as_str()) {
+            warnings.push(format!("duplicate import NID: {}", imp.nid_hash));
+        }
+    }
+    for imp in &image.imports {
+        if !image.import_libs.contains_key(&imp.library_id) {
+            warnings.push(format!(
+                "import {} references unknown library id {}",
+                imp.nid_hash, imp.library_id
+            ));
+        }
+    }
+    if image.entry_point == 0 {
+        warnings.push("entry point is zero".to_string());
+    }
+    warnings.sort();
+    warnings.dedup();
+
+    let needed = image.needed_files.clone();
+    let file_name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string());
+
+    ValidationReport {
+        schema_version: SCHEMA_VERSION,
+        tool: "ps5rs",
+        file: file_name,
+        sha256,
+        container: if image.is_self { "SELF" } else { "ELF" }.to_string(),
+        platform: image.platform.to_string(),
+        elf: ElfInfo {
+            arch: "x86_64".to_string(),
+            pie: image.metadata.elf_type == 3,
+            entry_point: format!("{:#x}", image.entry_point),
+        },
+        dependencies: DependencyInfo {
+            count: needed.len(),
+            libraries: needed,
+        },
+        symbols: SymbolCounts {
+            imports: image.imports.len(),
+            exports: image.exports.len(),
+        },
+        relocations: RelocationInfo {
+            total: image.relocations.len(),
+            by_kind,
+        },
+        plt: PltInfo {
+            entries: plt_entries,
+        },
+        nid_coverage: NidCoverage { known, unknown },
+        unknown_nids,
+        warnings,
+    }
+}
+
+fn print_report(report: &ValidationReport) {
+    println!("PS5 Binary Validation Report");
+    println!("============================");
+    println!();
+    println!("File:");
+    println!("  {}", report.file);
+    println!();
+    println!("Container:");
+    println!("  {}", report.container);
+    println!();
+    println!("ELF:");
+    println!("  {}", report.elf.arch);
+    println!("  {}", if report.elf.pie { "PIE" } else { "static" });
+    println!();
+    println!("Dependencies:");
+    println!("  {}", report.dependencies.count);
+    println!();
+    println!("Symbols:");
+    println!("  Imports: {}", report.symbols.imports);
+    println!("  Exports: {}", report.symbols.exports);
+    println!();
+    println!("Relocations:");
+    println!("  Total: {}", report.relocations.total);
+    println!();
+    for kind in &report.relocations.by_kind {
+        println!("  {:<12} {}", kind.kind, kind.count);
+    }
+    println!();
+    println!("PLT:");
+    println!("  Entries: {}", report.plt.entries);
+    println!();
+    println!("NID Coverage:");
+    println!(
+        "  Known: {} / {}",
+        report.nid_coverage.known, report.symbols.imports
+    );
+    println!(
+        "  Unknown: {} / {}",
+        report.nid_coverage.unknown, report.symbols.imports
+    );
+    if !report.unknown_nids.is_empty() {
+        println!();
+        println!("Unknown NIDs:");
+        for nid in &report.unknown_nids {
+            println!("  {nid}");
+        }
+    }
+    println!();
+    println!("Warnings:");
+    if report.warnings.is_empty() {
+        println!("  none");
+    } else {
+        for warning in &report.warnings {
+            println!("  - {warning}");
+        }
+    }
+}
+
+pub(crate) fn cmd_validate_binary(path: &PathBuf, json: bool, output: &Option<PathBuf>) {
+    let report = build_report(path);
+    if json {
+        write_to_output_or_stdout(output, &|w| {
+            serde_json::to_writer_pretty(w, &report).map_err(std::io::Error::other)
+        });
+    } else {
+        print_report(&report);
+    }
+}

--- a/crates/ps5-dashboard/src/data.rs
+++ b/crates/ps5-dashboard/src/data.rs
@@ -1375,16 +1375,15 @@ fn categorize_sce_library(name: &str) -> SceLibraryCategory {
     }
 }
 
+type SceLibAccumulator = (
+    Vec<String>,
+    Vec<String>,
+    usize,
+    HashMap<String, SceLibVersionEntry>,
+);
+
 fn compute_sce_stats(ds: &AnalysisDataset) -> Vec<SceLibraryStats> {
-    let mut lib_data: HashMap<
-        String,
-        (
-            Vec<String>,
-            Vec<String>,
-            usize,
-            HashMap<String, SceLibVersionEntry>,
-        ),
-    > = HashMap::new();
+    let mut lib_data: HashMap<String, SceLibAccumulator> = HashMap::new();
 
     for (name, doc) in &ds.images {
         let sce_libs = collect_sce_libraries(doc);

--- a/crates/ps5-image/src/lib.rs
+++ b/crates/ps5-image/src/lib.rs
@@ -56,19 +56,14 @@ pub struct StringAnalysis {
 // Image type — distinguishes eboot from PRX / SPRX / other modules
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub enum ImageType {
+    #[default]
     Eboot,
     Prx,
     Sprx,
     SelfModule,
     Unknown,
-}
-
-impl Default for ImageType {
-    fn default() -> Self {
-        Self::Eboot
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ps5-loader/src/graph.rs
+++ b/crates/ps5-loader/src/graph.rs
@@ -109,7 +109,7 @@ impl ModuleGraph {
         let mut order = Vec::new();
         let mut cycle_nodes = Vec::new();
 
-        fn dfs<'a>(
+        fn dfs(
             node: &str,
             graph: &ModuleGraph,
             visited: &mut HashSet<String>,
@@ -140,17 +140,17 @@ impl ModuleGraph {
         nodes.sort();
 
         for node in &nodes {
-            if !visited.contains(node) {
-                if !dfs(
+            if !visited.contains(node)
+                && !dfs(
                     node,
                     self,
                     &mut visited,
                     &mut in_progress,
                     &mut order,
                     &mut cycle_nodes,
-                ) {
-                    return Err(cycle_nodes);
-                }
+                )
+            {
+                return Err(cycle_nodes);
             }
         }
 

--- a/crates/ps5-loader/src/mapper.rs
+++ b/crates/ps5-loader/src/mapper.rs
@@ -210,15 +210,15 @@ pub fn load_elf(name: &str, elf_bytes: &[u8]) -> Result<LoadedModule> {
 
     let mut aliases = Vec::new();
     aliases.push(module_name.clone());
-    if let Some(ref sn) = soname {
-        if sn != &module_name {
-            aliases.push(sn.clone());
-        }
+    if let Some(ref sn) = soname
+        && sn != &module_name
+    {
+        aliases.push(sn.clone());
     }
-    if let Some(stripped) = module_name.strip_suffix(".prx") {
-        if !aliases.contains(&stripped.to_string()) {
-            aliases.push(stripped.to_string());
-        }
+    if let Some(stripped) = module_name.strip_suffix(".prx")
+        && !aliases.contains(&stripped.to_string())
+    {
+        aliases.push(stripped.to_string());
     }
 
     Ok(LoadedModule {

--- a/crates/ps5-loader/src/pipeline.rs
+++ b/crates/ps5-loader/src/pipeline.rs
@@ -29,6 +29,104 @@ use crate::resolver::CrossModuleResolver;
 /// Pass [`OfflineExportTable`] via `offline_exports` to enable known-system-
 /// function detection for system PRX exports (even when the system PRX is
 /// not loaded).
+struct LoadContext<'a, P>
+where
+    P: FnMut(&str) -> Option<Vec<u8>>,
+{
+    export_table: ExportTable,
+    offline_exports: Option<&'a OfflineExportTable>,
+    graph: ModuleGraph,
+    address_alloc: LoadAddressAllocator,
+    stub_alloc: StubAllocator,
+    loaded_modules: Vec<LoadedModule>,
+    total_resolved: u32,
+    total_known: u32,
+    total_stubbed: u32,
+    processed: HashSet<String>,
+    prx_provider: &'a mut P,
+}
+
+impl<P> LoadContext<'_, P>
+where
+    P: FnMut(&str) -> Option<Vec<u8>>,
+{
+    fn load_one(
+        &mut self,
+        name: &str,
+        elf: &ps5_elf::ElfImage,
+    ) -> Result<Option<LoadedModule>, LoaderError> {
+        let canonical = elf.soname.as_deref().unwrap_or(name);
+        if !self.processed.insert(canonical.to_string()) {
+            return Ok(self
+                .loaded_modules
+                .iter()
+                .find(|m| m.canonical_name() == canonical)
+                .cloned());
+        }
+
+        for needed_name in &elf.needed_files {
+            let Some(prx_bytes) = (self.prx_provider)(needed_name) else {
+                tracing::warn!(module = %needed_name, "PRX not found, marking unavailable");
+                self.graph.mark_unavailable(needed_name);
+                self.graph.add_edge(canonical, needed_name);
+                continue;
+            };
+            let prx_elf = ps5_elf::ElfImage::parse(&prx_bytes, None)
+                .map_err(|e| LoaderError(format!("{} parse: {e}", needed_name)))?;
+
+            let prx_canonical = prx_elf.soname.as_deref().unwrap_or(needed_name);
+            self.graph.add_edge(canonical, prx_canonical);
+
+            self.load_one(needed_name, &prx_elf)?;
+        }
+
+        let module_size = elf
+            .program_headers
+            .iter()
+            .filter(|ph| ph.is_load())
+            .map(|ph| ph.p_vaddr + ph.p_memsz)
+            .max()
+            .unwrap_or(0);
+        let load_bias = self.address_alloc.allocate(module_size);
+
+        let mut module = load_elf(name, elf.data)?;
+        module.load_bias = load_bias;
+        for region in &mut module.memory.regions {
+            region.vaddr = region.vaddr.wrapping_add(load_bias);
+        }
+
+        let _rel_summary = apply_relocations_with(&mut module, elf, None)?;
+        module.state = ModuleState::Relocated;
+
+        let export_count_before = self.export_table.len();
+        self.export_table.register_module(&module, elf);
+        module.exports_count = self.export_table.len() - export_count_before;
+
+        let mut resolver = CrossModuleResolver::new(
+            &self.export_table,
+            self.offline_exports,
+            &mut self.stub_alloc,
+        );
+        let _rel_summary = apply_relocations_with(&mut module, elf, Some(&mut resolver))?;
+        module.state = ModuleState::Linked;
+        module.imports_resolved = resolver.resolved_count();
+        module.imports_known = resolver.known_count();
+        module.imports_stubbed = resolver.stubbed_count();
+        module.per_library_imports = resolver.per_library_imports();
+
+        module.state = ModuleState::Initialized;
+        self.total_resolved += resolver.resolved_count();
+        self.total_known += resolver.known_count();
+        self.total_stubbed += resolver.stubbed_count();
+
+        self.graph
+            .add_node(module.canonical_name(), &module.aliases);
+
+        self.loaded_modules.push(module.clone());
+        Ok(Some(module))
+    }
+}
+
 pub fn load_modules(
     eboot_name: &str,
     eboot_bytes: &[u8],
@@ -38,204 +136,87 @@ pub fn load_modules(
     let eboot_elf = ps5_elf::ElfImage::parse(eboot_bytes, None)
         .map_err(|e| LoaderError(format!("eboot ELF parse: {e}")))?;
 
-    let mut export_table = ExportTable::new();
-    let mut graph = ModuleGraph::new();
-    let mut address_alloc = LoadAddressAllocator::default();
-    let mut stub_alloc = StubAllocator::new(0x0000_7fff_0000_0000);
-    let mut loaded_modules: Vec<LoadedModule> = Vec::new();
-    let mut total_resolved = 0u32;
-    let mut total_known = 0u32;
-    let mut total_stubbed = 0u32;
+    let mut ctx = LoadContext {
+        export_table: ExportTable::new(),
+        offline_exports,
+        graph: ModuleGraph::new(),
+        address_alloc: LoadAddressAllocator::default(),
+        stub_alloc: StubAllocator::new(0x0000_7fff_0000_0000),
+        loaded_modules: Vec::new(),
+        total_resolved: 0,
+        total_known: 0,
+        total_stubbed: 0,
+        processed: HashSet::new(),
+        prx_provider: &mut prx_provider,
+    };
 
-    // Track which modules we've already processed to avoid cycles.
-    let mut processed: HashSet<String> = HashSet::new();
-
-    // Load a single module and its transitive dependencies (DFS).
-    fn load_one(
-        name: &str,
-        elf: &ps5_elf::ElfImage,
-        export_table: &mut ExportTable,
-        offline_exports: Option<&OfflineExportTable>,
-        graph: &mut ModuleGraph,
-        address_alloc: &mut LoadAddressAllocator,
-        stub_alloc: &mut StubAllocator,
-        loaded_modules: &mut Vec<LoadedModule>,
-        total_resolved: &mut u32,
-        total_known: &mut u32,
-        total_stubbed: &mut u32,
-        processed: &mut HashSet<String>,
-        prx_provider: &mut impl FnMut(&str) -> Option<Vec<u8>>,
-    ) -> Result<Option<LoadedModule>, LoaderError> {
-        let canonical = elf.soname.as_deref().unwrap_or(name);
-        if !processed.insert(canonical.to_string()) {
-            return Ok(loaded_modules
-                .iter()
-                .find(|m| m.canonical_name() == canonical)
-                .cloned());
-        }
-
-        // Process transitive deps first
-        for needed_name in &elf.needed_files {
-            let Some(prx_bytes) = prx_provider(needed_name) else {
-                tracing::warn!(module = %needed_name, "PRX not found, marking unavailable");
-                graph.mark_unavailable(needed_name);
-                graph.add_edge(canonical, needed_name);
-                continue;
-            };
-            let prx_elf = ps5_elf::ElfImage::parse(&prx_bytes, None)
-                .map_err(|e| LoaderError(format!("{} parse: {e}", needed_name)))?;
-
-            let prx_canonical = prx_elf.soname.as_deref().unwrap_or(needed_name);
-            graph.add_edge(canonical, prx_canonical);
-
-            load_one(
-                needed_name,
-                &prx_elf,
-                export_table,
-                offline_exports,
-                graph,
-                address_alloc,
-                stub_alloc,
-                loaded_modules,
-                total_resolved,
-                total_known,
-                total_stubbed,
-                processed,
-                prx_provider,
-            )?;
-        }
-
-        // Map the module itself
-        let module_size = elf
-            .program_headers
-            .iter()
-            .filter(|ph| ph.is_load())
-            .map(|ph| (ph.p_vaddr + ph.p_memsz) as u64)
-            .max()
-            .unwrap_or(0);
-        let load_bias = address_alloc.allocate(module_size);
-
-        let mut module = load_elf(name, elf.data)?;
-        module.load_bias = load_bias;
-        for region in &mut module.memory.regions {
-            region.vaddr = region.vaddr.wrapping_add(load_bias);
-        }
-
-        // Phase 2: RELATIVE only
-        let _rel_summary = apply_relocations_with(&mut module, elf, None)?;
-        module.state = ModuleState::Relocated;
-
-        // Phase 3: Register exports
-        let export_count_before = export_table.len();
-        export_table.register_module(&module, elf);
-        module.exports_count = export_table.len() - export_count_before;
-
-        // Phase 4: Resolve imports
-        let mut resolver = CrossModuleResolver::new(export_table, offline_exports, stub_alloc);
-        let _rel_summary = apply_relocations_with(&mut module, elf, Some(&mut resolver))?;
-        module.state = ModuleState::Linked;
-        module.imports_resolved = resolver.resolved_count();
-        module.imports_known = resolver.known_count();
-        module.imports_stubbed = resolver.stubbed_count();
-        module.per_library_imports = resolver.per_library_imports();
-
-        module.state = ModuleState::Initialized;
-        *total_resolved += resolver.resolved_count();
-        *total_known += resolver.known_count();
-        *total_stubbed += resolver.stubbed_count();
-
-        graph.add_node(module.canonical_name(), &module.aliases);
-
-        loaded_modules.push(module.clone());
-        Ok(Some(module))
-    }
-
-    // Start with the eboot
     let eboot_canonical = eboot_elf.soname.as_deref().unwrap_or(eboot_name);
-    graph.add_node(eboot_canonical, &[]);
+    ctx.graph.add_node(eboot_canonical, &[]);
 
-    // Process eboot's transitive dependencies
     for needed_name in &eboot_elf.needed_files {
-        let Some(prx_bytes) = prx_provider(needed_name) else {
+        let Some(prx_bytes) = (ctx.prx_provider)(needed_name) else {
             tracing::warn!(module = %needed_name, "PRX not found, marking unavailable");
-            graph.mark_unavailable(needed_name);
-            graph.add_edge(eboot_canonical, needed_name);
+            ctx.graph.mark_unavailable(needed_name);
+            ctx.graph.add_edge(eboot_canonical, needed_name);
             continue;
         };
         let prx_elf = ps5_elf::ElfImage::parse(&prx_bytes, None)
             .map_err(|e| LoaderError(format!("{} parse: {e}", needed_name)))?;
 
         let prx_canonical = prx_elf.soname.as_deref().unwrap_or(needed_name);
-        graph.add_edge(eboot_canonical, prx_canonical);
+        ctx.graph.add_edge(eboot_canonical, prx_canonical);
 
-        load_one(
-            needed_name,
-            &prx_elf,
-            &mut export_table,
-            offline_exports,
-            &mut graph,
-            &mut address_alloc,
-            &mut stub_alloc,
-            &mut loaded_modules,
-            &mut total_resolved,
-            &mut total_known,
-            &mut total_stubbed,
-            &mut processed,
-            &mut prx_provider,
-        )?;
+        ctx.load_one(needed_name, &prx_elf)?;
     }
 
-    // Map + relocate the eboot itself (after all its deps)
-    {
-        let module_size = eboot_elf
-            .program_headers
-            .iter()
-            .filter(|ph| ph.is_load())
-            .map(|ph| (ph.p_vaddr + ph.p_memsz) as u64)
-            .max()
-            .unwrap_or(0);
-        let load_bias = address_alloc.allocate(module_size);
+    let module_size = eboot_elf
+        .program_headers
+        .iter()
+        .filter(|ph| ph.is_load())
+        .map(|ph| ph.p_vaddr + ph.p_memsz)
+        .max()
+        .unwrap_or(0);
+    let load_bias = ctx.address_alloc.allocate(module_size);
 
-        let mut module = load_elf(eboot_name, eboot_bytes)?;
-        module.load_bias = load_bias;
-        for region in &mut module.memory.regions {
-            region.vaddr = region.vaddr.wrapping_add(load_bias);
-        }
-
-        let _rel_summary = apply_relocations_with(&mut module, &eboot_elf, None)?;
-        module.state = ModuleState::Relocated;
-
-        let export_count_before = export_table.len();
-        export_table.register_module(&module, &eboot_elf);
-        module.exports_count = export_table.len() - export_count_before;
-
-        let mut resolver =
-            CrossModuleResolver::new(&export_table, offline_exports, &mut stub_alloc);
-        let _rel_summary = apply_relocations_with(&mut module, &eboot_elf, Some(&mut resolver))?;
-        module.state = ModuleState::Linked;
-        module.imports_resolved = resolver.resolved_count();
-        module.imports_known = resolver.known_count();
-        module.imports_stubbed = resolver.stubbed_count();
-        module.per_library_imports = resolver.per_library_imports();
-        total_resolved += resolver.resolved_count();
-        total_known += resolver.known_count();
-        total_stubbed += resolver.stubbed_count();
-
-        module.state = ModuleState::Initialized;
-
-        graph.add_node(module.canonical_name(), &module.aliases);
-
-        loaded_modules.push(module);
+    let mut module = load_elf(eboot_name, eboot_bytes)?;
+    module.load_bias = load_bias;
+    for region in &mut module.memory.regions {
+        region.vaddr = region.vaddr.wrapping_add(load_bias);
     }
+
+    let _rel_summary = apply_relocations_with(&mut module, &eboot_elf, None)?;
+    module.state = ModuleState::Relocated;
+
+    let export_count_before = ctx.export_table.len();
+    ctx.export_table.register_module(&module, &eboot_elf);
+    module.exports_count = ctx.export_table.len() - export_count_before;
+
+    let mut resolver =
+        CrossModuleResolver::new(&ctx.export_table, offline_exports, &mut ctx.stub_alloc);
+    let _rel_summary = apply_relocations_with(&mut module, &eboot_elf, Some(&mut resolver))?;
+    module.state = ModuleState::Linked;
+    module.imports_resolved = resolver.resolved_count();
+    module.imports_known = resolver.known_count();
+    module.imports_stubbed = resolver.stubbed_count();
+    module.per_library_imports = resolver.per_library_imports();
+    ctx.total_resolved += resolver.resolved_count();
+    ctx.total_known += resolver.known_count();
+    ctx.total_stubbed += resolver.stubbed_count();
+
+    module.state = ModuleState::Initialized;
+
+    ctx.graph.add_node(module.canonical_name(), &module.aliases);
+
+    ctx.loaded_modules.push(module);
 
     Ok(ModuleContext::new(
-        loaded_modules,
-        export_table,
-        graph,
-        stub_alloc,
-        total_resolved,
-        total_known,
-        total_stubbed,
+        ctx.loaded_modules,
+        ctx.export_table,
+        ctx.graph,
+        ctx.stub_alloc,
+        ctx.total_resolved,
+        ctx.total_known,
+        ctx.total_stubbed,
     ))
 }
 
@@ -373,7 +354,7 @@ mod tests {
         let phoff2 = phoff + 56;
         elf[phoff2..phoff2 + 4].copy_from_slice(&1u32.to_le_bytes());
         elf[phoff2 + 4..phoff2 + 8].copy_from_slice(&5u32.to_le_bytes());
-        elf[phoff2 + 8..phoff2 + 16].copy_from_slice(&(64u64 + 56 + 0).to_le_bytes());
+        elf[phoff2 + 8..phoff2 + 16].copy_from_slice(&(64u64 + 56).to_le_bytes());
         elf[phoff2 + 16..phoff2 + 24].copy_from_slice(&0x1000u64.to_le_bytes());
         elf[phoff2 + 32..phoff2 + 40].copy_from_slice(&(total_size as u64).to_le_bytes());
         elf[phoff2 + 40..phoff2 + 48].copy_from_slice(&(total_size as u64).to_le_bytes());
@@ -394,7 +375,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(ctx.modules.len() >= 1);
+        assert!(!ctx.modules.is_empty());
     }
 
     #[test]

--- a/crates/ps5-loader/src/relocation.rs
+++ b/crates/ps5-loader/src/relocation.rs
@@ -39,7 +39,7 @@ impl RelocationKind {
             6 => Self::GlobDat,
             7 => Self::JumpSlot,
             8 => Self::Relative,
-            16 | 17 | 18 => Self::Tls,
+            16..=18 => Self::Tls,
             _ => Self::Unknown(r_type),
         }
     }
@@ -216,84 +216,76 @@ pub fn apply_relocations_with(
                 })?;
             applied = true;
         } else if kind == RelocationKind::Abs64 {
-            if reloc.r_sym() != 0 {
-                if let Some(sym) = elf.symbols.get(reloc.r_sym() as usize) {
-                    if !sym.is_import && sym.st_value != 0 {
-                        // R_X86_64_64: *(S + A) = S + A, S = load_bias + st_value
-                        let s = module.load_bias.wrapping_add(sym.st_value);
-                        let value = s.wrapping_add(reloc.r_addend as u64);
-                        module
-                            .memory
-                            .write(address, &value.to_le_bytes())
-                            .map_err(|e| {
-                                RelocationError(format!(
-                                    "ABS64 write failed at 0x{:x}: {}",
-                                    address, e
-                                ))
-                            })?;
-                        applied = true;
-                        tracing::debug!(
-                            address,
-                            value,
-                            symbol = %sym.resolved_name,
-                            "ABS64 applied (local)",
-                        );
-                    } else if let Some(ref mut res) = resolver {
-                        let request = build_import_request(elf, reloc)?;
-                        let result = res.resolve(&request).map_err(|e| {
-                            RelocationError(format!("ABS64 import resolve failed: {e}"))
+            if reloc.r_sym() != 0
+                && let Some(sym) = elf.symbols.get(reloc.r_sym() as usize)
+            {
+                if !sym.is_import && sym.st_value != 0 {
+                    // R_X86_64_64: *(S + A) = S + A, S = load_bias + st_value
+                    let s = module.load_bias.wrapping_add(sym.st_value);
+                    let value = s.wrapping_add(reloc.r_addend as u64);
+                    module
+                        .memory
+                        .write(address, &value.to_le_bytes())
+                        .map_err(|e| {
+                            RelocationError(format!("ABS64 write failed at 0x{:x}: {}", address, e))
                         })?;
-                        let value = result.address();
-                        module
-                            .memory
-                            .write(address, &value.to_le_bytes())
-                            .map_err(|e| {
-                                RelocationError(format!(
-                                    "ABS64 import write at 0x{:x}: {}",
-                                    address, e
-                                ))
-                            })?;
-                        applied = true;
-                        tracing::debug!(
-                            address,
-                            value,
-                            symbol = %sym.resolved_name,
-                            kind = ?result,
-                            "ABS64 applied (import)",
-                        );
-                        match result {
-                            ResolveResult::Resolved(_) => summary.resolved_imports += 1,
-                            ResolveResult::Known(_) => summary.known_imports += 1,
-                            ResolveResult::Stubbed(_) => summary.stubbed_imports += 1,
-                        }
+                    applied = true;
+                    tracing::debug!(
+                        address,
+                        value,
+                        symbol = %sym.resolved_name,
+                        "ABS64 applied (local)",
+                    );
+                } else if let Some(ref mut res) = resolver {
+                    let request = build_import_request(elf, reloc)?;
+                    let result = res.resolve(&request).map_err(|e| {
+                        RelocationError(format!("ABS64 import resolve failed: {e}"))
+                    })?;
+                    let value = result.address();
+                    module
+                        .memory
+                        .write(address, &value.to_le_bytes())
+                        .map_err(|e| {
+                            RelocationError(format!("ABS64 import write at 0x{:x}: {}", address, e))
+                        })?;
+                    applied = true;
+                    tracing::debug!(
+                        address,
+                        value,
+                        symbol = %sym.resolved_name,
+                        kind = ?result,
+                        "ABS64 applied (import)",
+                    );
+                    match result {
+                        ResolveResult::Resolved(_) => summary.resolved_imports += 1,
+                        ResolveResult::Known(_) => summary.known_imports += 1,
+                        ResolveResult::Stubbed(_) => summary.stubbed_imports += 1,
                     }
                 }
             }
-        } else if let Some(ref mut res) = resolver {
-            if kind == RelocationKind::GlobDat || kind == RelocationKind::JumpSlot {
-                let request = build_import_request(elf, reloc)?;
-                let result = res
-                    .resolve(&request)
-                    .map_err(|e| RelocationError(format!("import resolve failed: {e}")))?;
-                let value = result.address();
-                module
-                    .memory
-                    .write(address, &value.to_le_bytes())
-                    .map_err(|e| {
-                        RelocationError(format!("import write at 0x{:x}: {}", address, e))
-                    })?;
-                applied = true;
-                tracing::debug!(
-                    address,
-                    value,
-                    kind = ?result,
-                    "import resolved",
-                );
-                match result {
-                    ResolveResult::Resolved(_) => summary.resolved_imports += 1,
-                    ResolveResult::Known(_) => summary.known_imports += 1,
-                    ResolveResult::Stubbed(_) => summary.stubbed_imports += 1,
-                }
+        } else if let Some(ref mut res) = resolver
+            && (kind == RelocationKind::GlobDat || kind == RelocationKind::JumpSlot)
+        {
+            let request = build_import_request(elf, reloc)?;
+            let result = res
+                .resolve(&request)
+                .map_err(|e| RelocationError(format!("import resolve failed: {e}")))?;
+            let value = result.address();
+            module
+                .memory
+                .write(address, &value.to_le_bytes())
+                .map_err(|e| RelocationError(format!("import write at 0x{:x}: {}", address, e)))?;
+            applied = true;
+            tracing::debug!(
+                address,
+                value,
+                kind = ?result,
+                "import resolved",
+            );
+            match result {
+                ResolveResult::Resolved(_) => summary.resolved_imports += 1,
+                ResolveResult::Known(_) => summary.known_imports += 1,
+                ResolveResult::Stubbed(_) => summary.stubbed_imports += 1,
             }
         }
 

--- a/crates/ps5-loader/src/resolver.rs
+++ b/crates/ps5-loader/src/resolver.rs
@@ -69,25 +69,24 @@ impl ImportResolver for CrossModuleResolver<'_> {
     fn resolve(&mut self, request: &ImportRequest) -> Result<ResolveResult, ImportError> {
         let lib = request.library.as_deref().unwrap_or("?");
         // 1. Runtime exports (modules actually loaded)
-        if let Some(nid) = request.nid {
-            if let Some(entry) = self.exports.get_by_nid(nid) {
-                self.resolved_count += 1;
-                let e = self.per_library.entry(lib.to_string()).or_insert([0, 0, 0]);
-                e[0] += 1;
-                return Ok(ResolveResult::Resolved(entry.address));
-            }
+        if let Some(nid) = request.nid
+            && let Some(entry) = self.exports.get_by_nid(nid)
+        {
+            self.resolved_count += 1;
+            let e = self.per_library.entry(lib.to_string()).or_insert([0, 0, 0]);
+            e[0] += 1;
+            return Ok(ResolveResult::Resolved(entry.address));
         }
         // 2. Offline exports (known system functions, not loaded)
-        if let Some(nid) = request.nid {
-            if let Some(offline) = self.offline {
-                if offline.get_by_nid(nid).is_some() {
-                    self.known_count += 1;
-                    let e = self.per_library.entry(lib.to_string()).or_insert([0, 0, 0]);
-                    e[1] += 1;
-                    let addr = self.stubs.resolve(request)?.address();
-                    return Ok(ResolveResult::Known(addr));
-                }
-            }
+        if let Some(nid) = request.nid
+            && let Some(offline) = self.offline
+            && offline.get_by_nid(nid).is_some()
+        {
+            self.known_count += 1;
+            let e = self.per_library.entry(lib.to_string()).or_insert([0, 0, 0]);
+            e[1] += 1;
+            let addr = self.stubs.resolve(request)?.address();
+            return Ok(ResolveResult::Known(addr));
         }
         // 3. Fallback to stub
         let result = self.stubs.resolve(request)?;


### PR DESCRIPTION
Ported REmu binary metrics into native \`ps5rs validate binary\` (deps/imports/relocs/PLT/NID coverage) with \`--json\`, added \`imports --catalog\` resolved mode, and fixed all workspace clippy warnings for CI.